### PR TITLE
Fixes and updates for workflow and rebrand

### DIFF
--- a/assets/js/paymaya.js
+++ b/assets/js/paymaya.js
@@ -102,7 +102,9 @@ jQuery(document).ready(function ($) {
                         window.location.reload();
                     }
                 })
-                .fail((jqXhr, textStatus, err) => console.log(err))
+                .fail((jqXhr, textStatus, err) => {
+                    alert(jqXhr.responseJSON['error'] || 'Something went wrong');
+                })
                 .always(() => {
                     capturePanel.unblock();
                 });

--- a/classes/cynder-paymaya.php
+++ b/classes/cynder-paymaya.php
@@ -23,6 +23,7 @@ define('CYNDER_PAYMAYA_PROCESS_PAYMENT_BLOCK', 'Process Payment');
 define('CYNDER_PAYMAYA_PROCESS_REFUND_BLOCK', 'Process Refund');
 define('CYNDER_PAYMAYA_MASS_REFUND_PAYMENT_BLOCK', 'Mass Refund');
 define('CYNDER_PAYMAYA_HANDLE_WEBHOOK_REQUEST_BLOCK', 'Handle Webhook Request');
+define('CYNDER_PAYMAYA_HANDLE_PAYMENT_WEBHOOK_REQUEST_BLOCK', 'Handle Payment Webhook Request');
 define('CYNDER_PAYMAYA_ADD_ACTION_BUTTONS_BLOCK', 'Add Action Buttons');
 define('CYNDER_PAYMAYA_AFTER_TOTALS_BLOCK', 'After Order Totals');
 define('CYNDER_PAYMAYA_CREATE_CHECKOUT_EVENT', 'createCheckout');
@@ -849,7 +850,7 @@ class Cynder_Paymaya_Gateway extends WC_Payment_Gateway
         $payment = json_decode($requestBody, true);
 
         if ($this->debug_mode) {
-            wc_get_logger()->log('info', '[' . CYNDER_PAYMAYA_HANDLE_WEBHOOK_REQUEST_BLOCK . '] Webhook payload ' . wc_print_r($payment, true));
+            wc_get_logger()->log('info', '[' . CYNDER_PAYMAYA_HANDLE_PAYMENT_WEBHOOK_REQUEST_BLOCK . '] Payment Webhook payload ' . wc_print_r($payment, true));
         }
 
         /** TO-DO: Do something with payment */

--- a/classes/cynder-paymaya.php
+++ b/classes/cynder-paymaya.php
@@ -711,128 +711,9 @@ class Cynder_Paymaya_Gateway extends WC_Payment_Gateway
     }
 
     public function handle_webhook_request() {
-        $isPostRequest = $_SERVER['REQUEST_METHOD'] === 'POST';
-        $wcApiQuery = sanitize_text_field($_GET['wc-api']);
-        $hasWcApiQuery = isset($wcApiQuery);
-        $hasCorrectQuery = $wcApiQuery === 'cynder_paymaya';
-
-        if (!$isPostRequest || !$hasWcApiQuery || !$hasCorrectQuery) {
-            status_header(400);
-            die();
-        }
-
-        $requestBody = file_get_contents('php://input');
-        $checkout = json_decode($requestBody, true);
-
-        if ($this->debug_mode) {
-            wc_get_logger()->log('info', '[' . CYNDER_PAYMAYA_HANDLE_WEBHOOK_REQUEST_BLOCK . '] Webhook payload ' . wc_print_r($checkout, true));
-        }
-
-        $referenceNumber = $checkout['requestReferenceNumber'];
-
-        $order = wc_get_order($referenceNumber);
-
-        if (empty($order)) {
-            wc_get_logger()->log('info', '[' . CYNDER_PAYMAYA_HANDLE_WEBHOOK_REQUEST_BLOCK . '] No transaction found with reference number '. $referenceNumber);
-
-            status_header(204);
-            die();
-        }
-
-        $checkoutStatus = $checkout['status'];
-        $paymentStatus = $checkout['paymentStatus'];
-
-        if ($checkoutStatus !== 'COMPLETED') {
-            wc_get_logger()->log('error', '[' . CYNDER_PAYMAYA_HANDLE_WEBHOOK_REQUEST_BLOCK . '] Failed to complete order because checkout is ' . $checkoutStatus . ' and  payment is ' . $paymentStatus);
-
-            status_header(200);
-            die();
-
-            return;
-        }
-
-        if ($paymentStatus === 'PAYMENT_FAILED') {
-            wc_get_logger()->log('info', '[' . CYNDER_PAYMAYA_HANDLE_WEBHOOK_REQUEST_BLOCK . '] Payment failed for order ' . $referenceNumber);
-
-            $order->update_status('failed', 'Payment failed');
-
-            status_header(200);
-            die();
-
-            return;
-        }
-
-        $orderMetadata = $order->get_meta_data();
-
-        $authorizationTypeMetadataIndex = array_search($this->id . '_authorization_type', array_column($orderMetadata, 'key'));
-        $authorizationTypeMetadata = $orderMetadata[$authorizationTypeMetadataIndex];
-
-        if ($this->debug_mode) {
-            wc_get_logger()->log('info', '[' . CYNDER_PAYMAYA_HANDLE_WEBHOOK_REQUEST_BLOCK . '] Authorization metadata ' . wc_print_r($authorizationTypeMetadata, true));
-        }
-
-        $totalAmountData = $checkout['totalAmount'];
-        $amountPaid = floatval($totalAmountData['value']);
-
-        /** Get txn ref number */
-        $transactionRefNumber = $checkout['transactionReferenceNumber'];
-
-        if ($authorizationTypeMetadata->value === 'none') {
-            /** For non-manual capture payments: */
-
-            /** With correct data based on assumptions */
-            if (abs($amountPaid-floatval($order->get_total())) < PHP_FLOAT_EPSILON) {
-                $order->payment_complete($transactionRefNumber);
-            } else {
-                wc_get_logger()->log('error', '[' . CYNDER_PAYMAYA_HANDLE_WEBHOOK_REQUEST_BLOCK . '] Amount mismatch. Open payment details on Maya dashboard with txn ref number ' . $transactionRefNumber);
-            }
-        } else {
-            /** For manual capture payments */
-
-            $payments = $this->client->getPaymentViaRrn($referenceNumber);
-
-            if ($this->debug_mode) {
-                wc_get_logger()->log('info', '[' . CYNDER_PAYMAYA_HANDLE_WEBHOOK_REQUEST_BLOCK . '] Payments via RRN ' . wc_print_r($payments, true));
-            }
-
-            if (array_key_exists("error", $payments)) {
-                wc_get_logger()->log('error', '[' . CYNDER_PAYMAYA_HANDLE_WEBHOOK_REQUEST_BLOCK . '] ' . $payments['error']);
-                return;
-            }
-
-            if (count($payments) === 0) {
-                wc_get_logger()->log('error', '[' . CYNDER_PAYMAYA_HANDLE_WEBHOOK_REQUEST_BLOCK . '] No payments associated to order ID ' . $referenceNumber);
-                return;
-            }
-
-            $capturedPayments = array_values(
-                array_filter(
-                    $payments,
-                    function ($payment) {
-                        if (empty($payment['receiptNumber']) || empty($payment['requestReferenceNumber'])) return false;
-                        return array_key_exists('authorizationType', $payment);
-                    }
-                )
-            );
-
-            if (count($capturedPayments) === 0) {
-                wc_get_logger()->log('error', '[' . CYNDER_PAYMAYA_HANDLE_WEBHOOK_REQUEST_BLOCK . '] No captured payments associated to order ID ' . $referenceNumber);
-                return;
-            }
-
-            if (count($capturedPayments) > 2) {
-                wc_get_logger()->log('error', '[' . CYNDER_PAYMAYA_HANDLE_WEBHOOK_REQUEST_BLOCK . '] Multiple captured payments associated to order ID ' . $referenceNumber);
-                return;
-            }
-
-            $capturedPayment = $capturedPayments[0];
-
-            if ($capturedPayment['amount'] !== $capturedPayment['capturedAmount']) return;
-
-            $order->payment_complete($transactionRefNumber);
-        }
-
-        wc_get_logger()->log('info', '[' . CYNDER_PAYMAYA_HANDLE_WEBHOOK_REQUEST_BLOCK . '] Webhook processing for checkout ID ' . $checkout['id'] . ' is complete');
+        /** Passthrough */
+        status_header(200);
+        die();
     }
 
     function handle_payment_webhook_request() {
@@ -853,10 +734,126 @@ class Cynder_Paymaya_Gateway extends WC_Payment_Gateway
             wc_get_logger()->log('info', '[' . CYNDER_PAYMAYA_HANDLE_PAYMENT_WEBHOOK_REQUEST_BLOCK . '] Payment Webhook payload ' . wc_print_r($payment, true));
         }
 
-        /** TO-DO: Do something with payment */
+        $referenceNumber = $payment['requestReferenceNumber'];
 
-        status_header(200);
-        die();
+        $order = wc_get_order($referenceNumber);
+
+        if (empty($order)) {
+            wc_get_logger()->log('info', '[' . CYNDER_PAYMAYA_HANDLE_PAYMENT_WEBHOOK_REQUEST_BLOCK . '] No transaction found with reference number '. $referenceNumber);
+
+            status_header(204);
+            die();
+        }
+
+        $orderMetadata = $order->get_meta_data();
+
+        $authorizationTypeMetadataIndex = array_search($this->id . '_authorization_type', array_column($orderMetadata, 'key'));
+        $authorizationTypeMetadata = $orderMetadata[$authorizationTypeMetadataIndex];
+
+        if ($this->debug_mode) {
+            wc_get_logger()->log('info', '[' . CYNDER_PAYMAYA_HANDLE_PAYMENT_WEBHOOK_REQUEST_BLOCK . '] Authorization metadata ' . wc_print_r($authorizationTypeMetadata, true));
+        }
+
+        $transactionRefNumber = $payment['id'];
+        $status = $payment['status'];
+        $amountPaid = $payment['amount'];
+
+        if ($authorizationTypeMetadata->value === 'none') {
+            /** For non-manual capture payments: */
+
+            /** With correct data based on assumptions */
+            if (abs($amountPaid-floatval($order->get_total())) < PHP_FLOAT_EPSILON && $status === 'PAYMENT_SUCCESS') {
+                $order->payment_complete($transactionRefNumber);
+            } else if ($status === 'PAYMENT_FAILED' || $status === 'PAYMENT_EXPIRED' || $status === 'AUTH_FAILED') {
+                $note = '';
+
+                switch ($status) {
+                    case 'PAYMENT_EXPIRED': {
+                        $note = 'Payment expired';
+                        break;
+                    }
+                    case 'AUTH_FAILED':
+                    case 'PAYMENT_FAILED':
+                    default: {
+                        $note = 'Payment failed';
+                    }
+                }
+
+                $order->update_status('failed', $note, true);
+            } else {
+                wc_get_logger()->log('error', '[' . CYNDER_PAYMAYA_HANDLE_PAYMENT_WEBHOOK_REQUEST_BLOCK . '] Amount mismatch. Open payment details on Maya dashboard with txn ref number ' . $transactionRefNumber);
+            }
+        } else {
+            /** Process manual captures */
+
+            $payments = $this->client->getPaymentViaRrn($referenceNumber);
+
+            if ($this->debug_mode) {
+                wc_get_logger()->log('info', '[' . CYNDER_PAYMAYA_HANDLE_PAYMENT_WEBHOOK_REQUEST_BLOCK . '] Payments via RRN ' . wc_print_r($payments, true));
+            }
+
+            if (array_key_exists("error", $payments)) {
+                wc_get_logger()->log('error', '[' . CYNDER_PAYMAYA_HANDLE_PAYMENT_WEBHOOK_REQUEST_BLOCK . '] ' . $payments['error']);
+                return;
+            }
+
+            if (count($payments) === 0) {
+                wc_get_logger()->log('error', '[' . CYNDER_PAYMAYA_HANDLE_PAYMENT_WEBHOOK_REQUEST_BLOCK . '] No payments associated to order ID ' . $referenceNumber);
+                return;
+            }
+
+            $authorizedPayments = array_values(
+                array_filter(
+                    $payments,
+                    function ($payment) {
+                        if (empty($payment['receiptNumber']) || empty($payment['requestReferenceNumber'])) return false;
+                        return array_key_exists('authorizationType', $payment);
+                    }
+                )
+            );
+
+            if (count($authorizedPayments) === 0) {
+                wc_get_logger()->log('error', '[' . CYNDER_PAYMAYA_HANDLE_PAYMENT_WEBHOOK_REQUEST_BLOCK . '] No captured payments associated to order ID ' . $referenceNumber);
+                return;
+            }
+
+            if (count($authorizedPayments) > 2) {
+                wc_get_logger()->log('error', '[' . CYNDER_PAYMAYA_HANDLE_PAYMENT_WEBHOOK_REQUEST_BLOCK . '] Multiple captured payments associated to order ID ' . $referenceNumber);
+                return;
+            }
+
+            $authorizedPayment = $authorizedPayments[0];
+
+            if ($authorizedPayment['amount'] === $authorizedPayment['capturedAmount']) {
+                if ($order->is_paid()) {
+                    $order->update_status('processing');
+                } else {
+                    $order->payment_complete($authorizedPayment['id']);
+                }
+            } else {
+                $note = '';
+
+                switch ($status) {
+                    case 'PAYMENT_SUCCESS': {
+                        $note = 'Successful payment ' . $payment['id'];
+                        break;
+                    }
+                    case 'PAYMENT_EXPIRED':
+                    case 'AUTH_FAILED':
+                    case 'PAYMENT_FAILED': {
+                        $note = 'Failed payment ' . $payment['id'];
+                        $order->update_status('on-hold');
+                        break;
+                    }
+                }
+
+                if (!empty($note)) {
+                    $order->add_order_note($note);
+                }
+            }
+        }
+
+        wc_get_logger()->log('info', '[' . CYNDER_PAYMAYA_HANDLE_PAYMENT_WEBHOOK_REQUEST_BLOCK . '] Webhook processing done for payment ' . $payment['id']);
     }
 
     function wc_order_item_add_action_buttons_callback($order) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Tags: payments, credit card
 Requires at least: 5.0
 Tested up to: 5.9
 Requires PHP: 5.6
-Stable tag: 1.0.9
+Stable tag: 1.1.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -50,6 +50,14 @@ To test payments, enable **Sandbox Mode**. This will let you transact test payme
 Automatic updates should work like a charm; as always though, ensure you backup your site just in case.
 
 == Changelog ==
+
+= 1.1.0 =
+*Release Date - October 13, 2022*
+
+* Refactor webhooks to listen for payment events instead of checkout
+* Fix error handling for invalid payments in manual captures
+* Updated production base URL for Maya API
+* Tested compatibility for WC 7.0.0
 
 = 1.0.9 =
 *Release Date - October 3, 2022*

--- a/wc-paymaya-payment-gateway.php
+++ b/wc-paymaya-payment-gateway.php
@@ -5,11 +5,11 @@
  * Description: Take credit and debit card payments via Maya.
  * Author: PayMaya
  * Author URI: https://www.paymaya.com
- * Version: 1.0.9
+ * Version: 1.1.0
  * Requires at least: 5.3.2
  * Tested up to: 6.0.2
  * WC requires at least: 3.9.3
- * WC tested up to: 6.9.4
+ * WC tested up to: 7.0.0
  *
  * @category Plugin
  * @package  CynderTech
@@ -53,7 +53,7 @@ function Paymaya_Init_Gateway_class()
     }
 
     define('CYNDER_PAYMAYA_MAIN_FILE', __FILE__);
-    define('CYNDER_PAYMAYA_VERSION', '1.0.9');
+    define('CYNDER_PAYMAYA_VERSION', '1.1.0');
     define('CYNDER_PAYMAYA_BASE_SANDBOX_URL',  'https://pg-sandbox.paymaya.com');
     define('CYNDER_PAYMAYA_BASE_PRODUCTION_URL',  'https://pg.maya.ph');
     define(

--- a/wc-paymaya-payment-gateway.php
+++ b/wc-paymaya-payment-gateway.php
@@ -55,7 +55,7 @@ function Paymaya_Init_Gateway_class()
     define('CYNDER_PAYMAYA_MAIN_FILE', __FILE__);
     define('CYNDER_PAYMAYA_VERSION', '1.0.9');
     define('CYNDER_PAYMAYA_BASE_SANDBOX_URL',  'https://pg-sandbox.paymaya.com');
-    define('CYNDER_PAYMAYA_BASE_PRODUCTION_URL',  'https://pg.paymaya.com');
+    define('CYNDER_PAYMAYA_BASE_PRODUCTION_URL',  'https://pg.maya.ph');
     define(
         'CYNDER_PAYMAYA_PLUGIN_URL',
         untrailingslashit(


### PR DESCRIPTION
Consider the following changes:
- Webhooks are now based on payment events; this now accounts failed payments which sets order status to Failed or On-hold
- Invalid manual captures are now being handled properly; **note that we only tested invalid amounts**; insufficient card balance cannot be tested in sandbox
- Updated Maya production URL
- Tested for WooCommerce 7.0.0