### PR TITLE
Fix webhook overrides

### DIFF
--- a/classes/cynder-paymaya.php
+++ b/classes/cynder-paymaya.php
@@ -29,6 +29,13 @@ define('CYNDER_PAYMAYA_AFTER_TOTALS_BLOCK', 'After Order Totals');
 define('CYNDER_PAYMAYA_CREATE_CHECKOUT_EVENT', 'createCheckout');
 define('CYNDER_PAYMAYA_VOID_PAYMENT_EVENT', 'voidPayment');
 define('CYNDER_PAYMAYA_REFUND_PAYMENT_EVENT', 'refundPayment');
+define('CYNDER_PAYMAYA_OVERRIDABLE_WEBHOOKS', array(
+    'CHECKOUT_SUCCESS',
+    'CHECKOUT_FAILURE',
+    'PAYMENT_SUCCESS',
+    'PAYMENT_FAILED',
+    'PAYMENT_EXPIRED',
+));
 
 /**
  * Paymaya Class
@@ -246,11 +253,21 @@ class Cynder_Paymaya_Gateway extends WC_Payment_Gateway
                 $this->add_error($webhooks["error"]);
             }
 
-            foreach($webhooks as $webhook) {
-                $deletedWebhook = $this->client->deleteWebhook($webhook["id"]);
+            wc_get_logger()->log('info', 'valid webhooks' . wc_print_r(CYNDER_PAYMAYA_OVERRIDABLE_WEBHOOKS, true));
 
-                if (array_key_exists("error", $deletedWebhook)) {
-                    $this->add_error($deletedWebhook["error"]);
+            foreach($webhooks as $webhook) {
+                /**
+                 * Only override webhook names that are being used by the plugin, disregard the rest
+                 */
+
+                wc_get_logger()->log('info', 'Webhook name ' . $webhook['name']);
+
+                if (in_array($webhook['name'], CYNDER_PAYMAYA_OVERRIDABLE_WEBHOOKS)) {
+                    $deletedWebhook = $this->client->deleteWebhook($webhook["id"]);
+
+                    if (array_key_exists("error", $deletedWebhook)) {
+                        $this->add_error($deletedWebhook["error"]);
+                    }
                 }
             }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Tags: payments, credit card
 Requires at least: 5.0
 Tested up to: 5.9
 Requires PHP: 5.6
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -50,6 +50,12 @@ To test payments, enable **Sandbox Mode**. This will let you transact test payme
 Automatic updates should work like a charm; as always though, ensure you backup your site just in case.
 
 == Changelog ==
+
+= 1.1.1 =
+*Release Date - January 9, 2022*
+
+* Fix saving settings overriding webhooks not being used by the plugin
+* Tested compatibility for WC 7.2.2
 
 = 1.1.0 =
 *Release Date - October 13, 2022*

--- a/wc-paymaya-payment-gateway.php
+++ b/wc-paymaya-payment-gateway.php
@@ -5,11 +5,11 @@
  * Description: Take credit and debit card payments via Maya.
  * Author: PayMaya
  * Author URI: https://www.paymaya.com
- * Version: 1.1.0
+ * Version: 1.1.1
  * Requires at least: 5.3.2
  * Tested up to: 6.0.2
  * WC requires at least: 3.9.3
- * WC tested up to: 7.0.0
+ * WC tested up to: 7.2.2
  *
  * @category Plugin
  * @package  CynderTech
@@ -53,7 +53,7 @@ function Paymaya_Init_Gateway_class()
     }
 
     define('CYNDER_PAYMAYA_MAIN_FILE', __FILE__);
-    define('CYNDER_PAYMAYA_VERSION', '1.1.0');
+    define('CYNDER_PAYMAYA_VERSION', '1.1.1');
     define('CYNDER_PAYMAYA_BASE_SANDBOX_URL',  'https://pg-sandbox.paymaya.com');
     define('CYNDER_PAYMAYA_BASE_PRODUCTION_URL',  'https://pg.maya.ph');
     define(


### PR DESCRIPTION
This should prevent other webhooks set in the Maya management dashboard to be overridden by the plugin, especially webhooks that are not utilized by the plugin.