### PR TITLE
Fix multiple webhook processing

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -51,8 +51,13 @@ Automatic updates should work like a charm; as always though, ensure you backup 
 
 == Changelog ==
 
+= 1.1.2 =
+*Release Date - March 8, 2023*
+* Fix multiple webhook processing for a single order
+* Tested compatibility for WP 6.1 and WC 7.3
+
 = 1.1.1 =
-*Release Date - January 9, 2022*
+*Release Date - January 9, 2023*
 
 * Fix saving settings overriding webhooks not being used by the plugin
 * Tested compatibility for WC 7.2.2

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Maya Business Plugin ===
 Tags: payments, credit card
 Requires at least: 5.0
-Tested up to: 5.9
+Tested up to: 6.1
 Requires PHP: 5.6
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/wc-paymaya-payment-gateway.php
+++ b/wc-paymaya-payment-gateway.php
@@ -5,11 +5,11 @@
  * Description: Take credit and debit card payments via Maya.
  * Author: PayMaya
  * Author URI: https://www.paymaya.com
- * Version: 1.1.1
+ * Version: 1.1.2
  * Requires at least: 5.3.2
- * Tested up to: 6.0.2
+ * Tested up to: 6.1.1
  * WC requires at least: 3.9.3
- * WC tested up to: 7.2.2
+ * WC tested up to: 7.3.0
  *
  * @category Plugin
  * @package  CynderTech
@@ -53,7 +53,7 @@ function Paymaya_Init_Gateway_class()
     }
 
     define('CYNDER_PAYMAYA_MAIN_FILE', __FILE__);
-    define('CYNDER_PAYMAYA_VERSION', '1.1.1');
+    define('CYNDER_PAYMAYA_VERSION', '1.1.2');
     define('CYNDER_PAYMAYA_BASE_SANDBOX_URL',  'https://pg-sandbox.paymaya.com');
     define('CYNDER_PAYMAYA_BASE_PRODUCTION_URL',  'https://pg.maya.ph');
     define(


### PR DESCRIPTION
This PR contains a fix for processing multiple webhooks related to a specific order. Basically, if an order is already paid, no other webhooks related to that order will be processed. This is to account for delays in webhook sending due to its asynchronous nature.

This PR also is tested for compatibility with the latest version of WordPress and WooCommerce.